### PR TITLE
fix: 起動時・終了時のバージョン表示を変更

### DIFF
--- a/VRCXDiscordTracker/Core/AppConstants.cs
+++ b/VRCXDiscordTracker/Core/AppConstants.cs
@@ -9,6 +9,11 @@ internal class AppConstants
     public static readonly string AppName = Assembly.GetExecutingAssembly().GetName().Name ?? string.Empty;
 
     /// <summary>
+    /// アプリケーションバージョン
+    /// </summary>
+    public static readonly Version AppVersion = Assembly.GetExecutingAssembly().GetName().Version ?? new Version(0, 0, 0);
+
+    /// <summary>
     /// VRCXのデフォルトのSQLiteデータベースのパス
     /// </summary>
     public static readonly string VRCXDefaultDatabasePath = Path.Combine(Environment.GetFolderPath(Environment.SpecialFolder.ApplicationData), "VRCX", "VRCX.sqlite3");

--- a/VRCXDiscordTracker/Core/Notification/DiscordNotificationService.cs
+++ b/VRCXDiscordTracker/Core/Notification/DiscordNotificationService.cs
@@ -81,7 +81,7 @@ internal class DiscordNotificationService(MyLocation myLocation, List<InstanceMe
             Timestamp = DateTime.UtcNow,
             Footer = new EmbedFooterBuilder
             {
-                Text = $"{AppConstants.AppName} {Assembly.GetExecutingAssembly().GetName().Version}",
+                Text = $"{AppConstants.AppName} {version.Major}.{version.Minor}.{version.Build}",
             }
         }.Build());
     }
@@ -100,7 +100,7 @@ internal class DiscordNotificationService(MyLocation myLocation, List<InstanceMe
             Timestamp = DateTime.UtcNow,
             Footer = new EmbedFooterBuilder
             {
-                Text = $"{AppConstants.AppName} {Assembly.GetExecutingAssembly().GetName().Version}",
+                Text = $"{AppConstants.AppName} {version.Major}.{version.Minor}.{version.Build}",
             }
         }.Build());
     }

--- a/VRCXDiscordTracker/Core/Notification/DiscordNotificationService.cs
+++ b/VRCXDiscordTracker/Core/Notification/DiscordNotificationService.cs
@@ -1,5 +1,4 @@
 using System.Globalization;
-using System.Reflection;
 using System.Text.Json;
 using Discord;
 using Discord.Webhook;
@@ -81,7 +80,7 @@ internal class DiscordNotificationService(MyLocation myLocation, List<InstanceMe
             Timestamp = DateTime.UtcNow,
             Footer = new EmbedFooterBuilder
             {
-                Text = $"{AppConstants.AppName} {version.Major}.{version.Minor}.{version.Build}",
+                Text = $"{AppConstants.AppName} {AppConstants.AppVersion.Major}.{AppConstants.AppVersion.Minor}.{AppConstants.AppVersion.Build}",
             }
         }.Build());
     }
@@ -100,7 +99,7 @@ internal class DiscordNotificationService(MyLocation myLocation, List<InstanceMe
             Timestamp = DateTime.UtcNow,
             Footer = new EmbedFooterBuilder
             {
-                Text = $"{AppConstants.AppName} {version.Major}.{version.Minor}.{version.Build}",
+                Text = $"{AppConstants.AppName} {AppConstants.AppVersion.Major}.{AppConstants.AppVersion.Minor}.{AppConstants.AppVersion.Build}",
             }
         }.Build());
     }
@@ -195,8 +194,6 @@ internal class DiscordNotificationService(MyLocation myLocation, List<InstanceMe
     /// <exception cref="FormatException">Location文字列がコロンで区切られていない場合</exception>
     private Embed GetEmbed()
     {
-        Version version = Assembly.GetExecutingAssembly().GetName().Version ?? new Version(0, 0, 0);
-
         // インスタンスIDは、Locationの:よりあと
         var locationParts = myLocation.LocationId.Split(':');
         if (locationParts.Length != 2)
@@ -215,7 +212,7 @@ internal class DiscordNotificationService(MyLocation myLocation, List<InstanceMe
             Timestamp = DateTime.UtcNow,
             Footer = new EmbedFooterBuilder
             {
-                Text = $"{AppConstants.AppName} {version.Major}.{version.Minor}.{version.Build}",
+                Text = $"{AppConstants.AppName} {AppConstants.AppVersion.Major}.{AppConstants.AppVersion.Minor}.{AppConstants.AppVersion.Build}",
             }
         };
 


### PR DESCRIPTION
`Footer` プロパティの `Text` フィールドを変更し、アプリケーションのバージョン情報を `Assembly.GetExecutingAssembly().GetName().Version` から `version.Major}.{version.Minor}.{version.Build` に更新しました。