### PR TITLE
feat: 未キャッチエラーハンドリング処理の改善

### DIFF
--- a/VRCXDiscordTracker/Program.cs
+++ b/VRCXDiscordTracker/Program.cs
@@ -1,4 +1,5 @@
 using System.Diagnostics;
+using System.Globalization;
 using System.Runtime.InteropServices;
 using System.Text;
 using Microsoft.Toolkit.Uwp.Notifications;
@@ -87,21 +88,15 @@ internal static partial class Program
         Console.WriteLine($"Message: {e.Message}");
         Console.WriteLine($"InnerException: {e.InnerException?.Message}");
         Console.WriteLine($"StackTrace: {e.StackTrace}");
-
-        var errorDetailAndStacktrace = "----- Error Details -----\n" +
-            e.Message + "\n" +
-            e.InnerException?.Message + "\n" +
-            "\n" +
-            "----- StackTrace -----\n" +
-            e.StackTrace + "\n";
+        Console.WriteLine($"InnerException StackTrace: {e.InnerException?.StackTrace}");
 
         DialogResult result = MessageBox.Show(
             "An error has occurred and the operation has stopped.\n" +
             "It would be helpful if you could report this bug using GitHub issues!\n" +
             "https://github.com/tomacheese/" + AppConstants.AppName + "/issues\n" +
             "\n" +
-            errorDetailAndStacktrace +
-            "\n" +
+            GetErrorDetails(e, false) +
+            "\n\n" +
             "Click OK to open the Create GitHub issue page.\n" +
             "Click Cancel to close this application.",
             $"Error ({exceptionType})",
@@ -112,10 +107,51 @@ internal static partial class Program
         {
             Process.Start(new ProcessStartInfo()
             {
-                FileName = "https://github.com/tomacheese/" + AppConstants.AppName + "/issues/new?body=" + Uri.EscapeDataString(errorDetailAndStacktrace),
+                FileName = "https://github.com/tomacheese/" + AppConstants.AppName + "/issues/new?body=" + Uri.EscapeDataString(GetErrorDetails(e, true)),
                 UseShellExecute = true,
             });
         }
         Application.Exit();
+    }
+
+    private static string GetErrorDetails(Exception e, bool isMarkdown)
+    {
+        var sb = new StringBuilder();
+        var fence = isMarkdown ? "```" : string.Empty;
+
+        void AppendSection(string title, string content)
+        {
+            if (isMarkdown)
+            {
+                sb.AppendLine(CultureInfo.InvariantCulture, $"## {title}\n\n{fence}\n{content}\n{fence}\n");
+            }
+            else
+            {
+                sb.AppendLine(CultureInfo.InvariantCulture, $"----- {title} -----\n{content}\n");
+            }
+        }
+
+        Exception? current = e;
+        var level = 0;
+        while (current != null)
+        {
+            var title = level == 0
+                ? "Error"
+                : $"Inner Exception (Level {level})";
+            AppendSection(title,
+                (current.Message ?? "<no message>") + "\n" +
+                (current.StackTrace ?? "<no trace>"));
+
+            current = current.InnerException;
+            level++;
+        }
+
+        // Environment info
+        AppendSection("Environment",
+            $"OS: {Environment.OSVersion}\n" +
+            $"CLR: {Environment.Version}\n" +
+            $"App: {AppConstants.AppName} {AppConstants.AppVersion}");
+
+        return sb.ToString().Trim();
     }
 }


### PR DESCRIPTION
https://github.com/tomacheese/VRCXDiscordTracker/pull/33#discussion_r2095578746 での指摘に基づき、未キャッチエラーのハンドリング時の表示を改善します。

## Inner Exception なし

![image](https://github.com/user-attachments/assets/18a970fb-fdaf-42af-b8e1-17e813648a21)
![image](https://github.com/user-attachments/assets/17f79757-0897-4169-ba29-eb394de235b5)

## Inner Exception あり

![image](https://github.com/user-attachments/assets/ca4485ff-80a1-4357-b2ba-a59d9d579d4c)
![image](https://github.com/user-attachments/assets/cdef9254-8d3e-4417-a1e3-b8725cddfa3a)
