### PR TITLE
fix: Mainメソッドの非同期処理を同期処理に変更

### DIFF
--- a/VRCXDiscordTracker/Program.cs
+++ b/VRCXDiscordTracker/Program.cs
@@ -20,7 +20,7 @@ internal static partial class Program
     private static partial bool AllocConsole();
 
     [STAThread]
-    static async Task Main()
+    static void Main()
     {
         if (ToastNotificationManagerCompat.WasCurrentProcessToastActivated())
         {
@@ -49,12 +49,15 @@ internal static partial class Program
         }
         else
         {
-            var existsUpdate = await UpdateChecker.Check();
-            if (existsUpdate)
+            Task.Run(async () =>
             {
-                Console.WriteLine("Found update. Exiting...");
-                return;
-            }
+                var existsUpdate = await UpdateChecker.Check();
+                if (existsUpdate)
+                {
+                    Console.WriteLine("Found update. Exiting...");
+                    return;
+                }
+            }).Wait();
         }
 
         ApplicationConfiguration.Initialize();
@@ -74,7 +77,7 @@ internal static partial class Program
 
             if (AppConfig.NotifyOnStart)
             {
-                await DiscordNotificationService.SendAppStartMessage().ContinueWith(t =>
+                DiscordNotificationService.SendAppStartMessage().ContinueWith(t =>
                 {
                     if (t.IsFaulted)
                     {

--- a/VRCXDiscordTracker/Program.cs
+++ b/VRCXDiscordTracker/Program.cs
@@ -87,11 +87,17 @@ internal static partial class Program
             }
         }
 
-        Application.ApplicationExit += async (s, e) =>
+        Application.ApplicationExit += (s, e) =>
         {
             if (AppConfig.NotifyOnExit)
             {
-                await DiscordNotificationService.SendAppExitMessage();
+                DiscordNotificationService.SendAppExitMessage().ContinueWith(t =>
+                {
+                    if (t.IsFaulted)
+                    {
+                        Console.WriteLine($"Error sending app exit message: {t.Exception?.Message}");
+                    }
+                });
             }
             Controller?.Dispose();
             ToastNotificationManagerCompat.Uninstall();

--- a/VRCXDiscordTracker/Program.cs
+++ b/VRCXDiscordTracker/Program.cs
@@ -91,13 +91,7 @@ internal static partial class Program
         {
             if (AppConfig.NotifyOnExit)
             {
-                DiscordNotificationService.SendAppExitMessage().ContinueWith(t =>
-                {
-                    if (t.IsFaulted)
-                    {
-                        Console.WriteLine($"Error sending app exit message: {t.Exception?.Message}");
-                    }
-                });
+                DiscordNotificationService.SendAppExitMessage().GetAwaiter().GetResult();
             }
             Controller?.Dispose();
             ToastNotificationManagerCompat.Uninstall();


### PR DESCRIPTION
`Main` メソッドのシグネチャを `async Task` から `void` に変更し、非同期処理の扱いを変更しました。 `UpdateChecker.Check()` の呼び出しを `Task.Run` 内に移動し、更新チェックの結果に基づく処理の流れを変更しました。 また、`DiscordNotificationService.SendAppStartMessage()` の呼び出しを `await` なしで行うようにし、非同期処理の結果を待たずに次の処理に進むようにしました。