### PR TITLE
feat: Disposeメソッドを持つクラスをIDisposableに変更

### DIFF
--- a/VRCXDiscordTracker/Core/VRCX/VRCXDatabase.cs
+++ b/VRCXDiscordTracker/Core/VRCX/VRCXDatabase.cs
@@ -8,7 +8,7 @@ namespace VRCXDiscordTracker.Core.VRCX;
 /// <summary>
 /// VRCXのSQLiteデータベースを操作するクラス
 /// </summary>
-internal class VRCXDatabase
+internal class VRCXDatabase : IDisposable
 {
     /// <summary>
     /// SQLiteデータベースの接続

--- a/VRCXDiscordTracker/Core/VRCXDiscordTrackerController.cs
+++ b/VRCXDiscordTracker/Core/VRCXDiscordTrackerController.cs
@@ -9,7 +9,7 @@ namespace VRCXDiscordTracker.Core;
 /// <summary>
 /// VRCXDiscordTrackerのコントローラークラス
 /// </summary>
-internal class VRCXDiscordTrackerController
+internal class VRCXDiscordTrackerController : IDisposable
 {
     /// <summary>
     /// VRCXのSQLiteデータベースのパス


### PR DESCRIPTION
`VRCXDatabase` と `VRCXDiscordTrackerController` クラスに `IDisposable` インターフェースを実装しました。これにより、リソースの解放が適切に行えるようになります。

- close #47 