### PR TITLE
feat: migrate from System.Data.SQLite to Microsoft.Data.Sqlite

### DIFF
--- a/VRCXDiscordTracker/Core/VRCX/VRCXDatabase.cs
+++ b/VRCXDiscordTracker/Core/VRCX/VRCXDatabase.cs
@@ -1,6 +1,6 @@
-using Microsoft.Data.Sqlite;
 using System.Globalization;
 using System.Reflection;
+using Microsoft.Data.Sqlite;
 using VRCXDiscordTracker.Core.VRChat;
 
 namespace VRCXDiscordTracker.Core.VRCX;
@@ -71,7 +71,7 @@ internal class VRCXDatabase : IDisposable
     public string GetVRChatUserId()
     {
         Console.WriteLine("VRCXDatabase.GetVRChatUserId()");
-        using var cmd = _conn.CreateCommand();
+        using SqliteCommand cmd = _conn.CreateCommand();
         // configs テーブルで、key = "config:lastuserloggedin" の value
         cmd.CommandText = "SELECT value FROM configs WHERE key = 'config:lastuserloggedin'";
         using SqliteDataReader reader = cmd.ExecuteReader();
@@ -90,7 +90,7 @@ internal class VRCXDatabase : IDisposable
         var sql = GetEmbedFileContent("VRCXDiscordTracker.Core.VRCX.Queries.myLocations.sql");
 
         var myLocations = new List<MyLocation>();
-        using (var cmd = _conn.CreateCommand())
+        using (SqliteCommand cmd = _conn.CreateCommand())
         {
             cmd.CommandText = sql;
             cmd.Parameters.AddWithValue(":target_user_id", vrchatUserId);
@@ -149,7 +149,7 @@ internal class VRCXDatabase : IDisposable
         var sql = GetEmbedFileContent("VRCXDiscordTracker.Core.VRCX.Queries.instanceMembers.sql").Replace("@{friendTableName}", friendTableName);
 
         var instanceMembers = new List<InstanceMember>();
-        using (var cmd = _conn.CreateCommand())
+        using (SqliteCommand cmd = _conn.CreateCommand())
         {
             cmd.CommandText = sql;
             cmd.Parameters.AddWithValue(":join_created_at", FormatDateTime(myLocation.JoinCreatedAt.AddSeconds(-1)));

--- a/VRCXDiscordTracker/VRCXDiscordTracker.csproj
+++ b/VRCXDiscordTracker/VRCXDiscordTracker.csproj
@@ -29,7 +29,7 @@
   <ItemGroup>
     <PackageReference Include="Discord.Net.Webhook" Version="3.18.0" />
     <PackageReference Include="Microsoft.Toolkit.Uwp.Notifications" Version="7.1.3" />
-    <PackageReference Include="System.Data.SQLite" Version="1.0.119" />
+    <PackageReference Include="Microsoft.Data.Sqlite" Version="9.0.0" />
   </ItemGroup>
 
   <ItemGroup>


### PR DESCRIPTION
## 概要

System.Data.SQLite から Microsoft.Data.Sqlite に移行しました。

## 変更内容

- パッケージを System.Data.SQLite v1.0.119 から Microsoft.Data.Sqlite v9.0.0 に変更
- VRCXDatabase.cs の SQLite 関連クラスを Microsoft.Data.Sqlite のものに更新
  - SQLiteConnection → SqliteConnection
  - SQLiteCommand → _conn.CreateCommand()
  - SQLiteDataReader → SqliteDataReader
  - ReadOnly = true → Mode = SqliteOpenMode.ReadOnly

## テスト

- ✅ ビルド成功
- ✅ アプリケーション起動確認
- ✅ プロセスが正常に動作